### PR TITLE
Use small-caps font-variant to fit in better with text on page

### DIFF
--- a/substitutions/js/substitutions.js
+++ b/substitutions/js/substitutions.js
@@ -36,6 +36,7 @@ chrome.runtime.sendMessage("config", function(response) {
       '}' +
       '.xkcdSubstitutionsExtensionSubbed {' +
       '  font-family: xkcdSubstitutionsFont !important;' +
+      '  font-variant: small-caps;' +
       '}';
     document.head.appendChild(stylesheet);
   }


### PR DESCRIPTION
Hey! I like your variant, using the xkcd font in the substitutions.

I think it would fit in a bit better if you used the small-caps font-variant, so things look like this:
![multicolor rgb backlit full sized blue switch mechanical leopard - small-caps](https://cloud.githubusercontent.com/assets/1148665/24077787/ec717f3e-0c26-11e7-8cb3-46de765adcc8.png)

instead of this:
![multicolor rgb backlit full sized blue switch mechanical keyboard - full caps](https://cloud.githubusercontent.com/assets/1148665/24077789/f1341f54-0c26-11e7-9566-94ffe24f3f3c.png)
